### PR TITLE
Fixing multi line updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple way to retrieve and update variables from a .env file.
 npm i -g @mikegarde/dotenv-cli
 ```
 
-## Usage
+## CLI Usage
 
 Get a value from a .env file:
 
@@ -34,7 +34,7 @@ Return a single value from a .env file as JSON:
 dotenv <key> --json
 ```
 
-## Multiline Values
+### Multiline Values
 
 The default behavior is to output a single line value. If you want to output a multiline value, 
 you can use the `--multiline` flag:
@@ -50,7 +50,7 @@ $ dotenv RSA_KEY
 -----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFE...
 ```
 
-## Setting a Value
+### Setting a Value
 
 Set a value in a .env file:
 

--- a/src/envObject.ts
+++ b/src/envObject.ts
@@ -1,0 +1,101 @@
+/**
+ * Used to create an EnvObject that can be used to store environment variables
+ */
+class EnvValue {
+  value: string;
+  lineStart: number;
+  lineEnd: number;
+
+  constructor(value: string, lineStart: number = -1, lineEnd: number = -1) {
+    this.value = value;
+    this.lineStart = lineStart;
+    this.lineEnd = lineEnd;
+  }
+}
+
+/**
+ * Used to create an object that can be used to store environment variables
+ */
+class EnvObject {
+  [key: string]: EnvValue | any;
+
+  /**
+   * Constructor for the EnvObject class.
+   */
+  constructor() {
+    return new Proxy(this, {
+      /**
+       * GET trap that is used to get the value of EnvObject
+       */
+      // get(target, key: PropertyKey, receiver) {
+      //   if (typeof key === 'string' && typeof target[key] === 'object' && target[key] !== null) {
+      //     console.log('getting', key, target[key]);
+      //     return Reflect.get(target[key], 'value', receiver);
+      //   } else {
+      //     return Reflect.get(target, key, receiver);
+      //   }
+      // },
+      /**
+       * SET trap that is used to set the value of EnvObject
+       */
+      set(target, key: PropertyKey, value, receiver) {
+        if (typeof key !== 'string') {
+          key = 'value';
+        }
+        if (value instanceof EnvValue) {
+          target[key] = value;
+          return true;
+        }
+        if (typeof value === 'object' && value !== null) {
+          target[key] = new EnvValue(value.value, value.lineStart, value.lineEnd);
+          return true;
+        }
+        if (typeof value === 'string') {
+          if (target[key] instanceof EnvValue) {
+            target[key] = value;
+          } else {
+            target[key] = new EnvValue(value);
+          }
+
+        }
+        if (typeof target[key] === 'object' && target[key] !== null) {
+          target[key].value = value;
+        } else {
+          // TODO: let's not allow this
+          target[key as string] = {
+            value: value,
+            lineStart: -1, // You might want to set these values appropriately
+            lineEnd: -1
+          };
+        }
+        return true;
+      }
+    });
+  }
+
+  /**
+   * Used to convert the EnvObject to an key/value object
+   */
+  toObj(): { [key: string]: string } {
+    let obj: { [key: string]: string } = {};
+
+    for (const key in this) {
+      const keyName = key as string;
+      const value = this[keyName].value;
+
+      if (typeof value === 'string') {
+        obj[keyName] = value;
+      }
+    }
+    return obj;
+  }
+
+  /**
+   * Used to convert the EnvObject to a JSON string
+   */
+  toJsonString(): string {
+    return JSON.stringify(this.toObj());
+  }
+}
+
+export default EnvObject;

--- a/src/escapeAndQuote.ts
+++ b/src/escapeAndQuote.ts
@@ -10,7 +10,7 @@ function escapeAndQuote(str: string, quote: boolean): string {
     str = str.slice(1, -1);
   }
 
-  let needsQuotes = quote || /\s|"/.test(str);
+  const needsQuotes: boolean = quote || /\s|"/.test(str);
 
   // Only escape double quotes if necessary
   if (needsQuotes && /(?<!\\)"/.test(str)) {


### PR DESCRIPTION
First version assumed a key=value will only be on one line, this acknowledges that some values will be multiple lines