### PR TITLE
add support for DOTENV_FILE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Delete a value from a .env file:
 dotenv <key> --delete
 ```
 
+### Using DOTENV_FILE Environment Variable
+
+You can define the `DOTENV_FILE` environment variable in your shell or script to specify the `.env` file to use, instead 
+of passing the `--file` option every time.
+
+```shell
+export DOTENV_FILE=.env.example
+dotenv <key>
+```
+
+This will use the `.env.example` file automatically. If the `--file` option is provided, it will override the 
+`DOTENV_FILE` environment variable.
+
 ## Examples
 
 ### RSA Key Pair
@@ -111,13 +124,13 @@ dotenv APP_VERSION --set $NEW_VERSION
 Make it pretty with `jq`:
 
 ```shell
-dotenv --json | jq
+dotenv | jq
 ```
 
 Or filter the output:
 
 ```shell
-$ dotenv --json | jq 'to_entries | map(select(.key | startswith("DB_")))[] | "\(.key)=\(.value)"'
+$ dotenv | jq 'to_entries | map(select(.key | startswith("DB_")))[] | "\(.key)=\(.value)"'
 "DB_HOST=localhost"
 "DB_USER=root"
 "DB_PASS=password"

--- a/src/app.ts
+++ b/src/app.ts
@@ -44,7 +44,7 @@ async function app() {
     throw new RuleViolationError(`Error reading from stdin: ${err}`);
   });
 
-  const envFilePath: string = cliOptions.file || '.env';
+  const envFilePath: string = cliOptions.file || process.env.DOTENV_FILE || '.env';
   const fullEnvPath: string = path.resolve(envFilePath);
   const keys: string[]      = program.args;
   const set: string         = cliOptions.set;
@@ -65,7 +65,7 @@ async function app() {
 
   // Must have a .env file
   if (!fs.existsSync(fullEnvPath)) {
-    throw new RuleViolationError(`.env file not found: ${fullEnvPath}`);
+    throw new RuleViolationError(`File not found: ${fullEnvPath}`);
   }
 
   let options: Options = {

--- a/tests/app.tests.ts
+++ b/tests/app.tests.ts
@@ -19,8 +19,14 @@ describe('app.ts', () => {
       const errorMsg: string  = buffer.toString('utf8');
 
       expect(parsedError.status).toEqual(1);
-      expect(errorMsg).toContain('.env file not found');
+      expect(errorMsg).toContain('File not found');
     }
+  });
+
+  test('uses DOTENV_FILE environment variable', () => {
+    const result = execSync(`export DOTENV_FILE=${envPath} && node ${appPath} NAME`);
+    expect(result.toString().trim()).toBe('dotenv-cli');
+    delete process.env.DOTENV_FILE;
   });
 
   test('read simple value', () => {


### PR DESCRIPTION
- Allow users to specify the `.env` file using the `DOTENV_FILE` environment variable.
- Updated logic to prioritize `--file` CLI option, then `DOTENV_FILE`, and default to `.env`.
- Added unit tests to verify behavior when `DOTENV_FILE` is set.
- Updated `README.md` with usage instructions for the `DOTENV_FILE` environment variable.