### PR TITLE
Add automated multi-file release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,184 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: Release version/tag to create or complete. Defaults to package.json version.
+        required: false
+        type: string
+      release_draft:
+        description: Create a draft release when this workflow creates the release.
+        required: true
+        default: true
+        type: boolean
+      release_prerelease:
+        description: Mark the release as a prerelease when this workflow creates the release.
+        required: true
+        default: false
+        type: boolean
+      clobber_assets:
+        description: Replace existing release assets with the same name.
+        required: true
+        default: false
+        type: boolean
+  release:
+    types: [created, published]
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.release_version || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  build-assets:
+    name: Build ${{ matrix.target }}
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            archive: tar.gz
+            platform: unknown-linux-gnu
+            arch: x86_64
+            executable: dotenv
+            apt: ''
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz
+            platform: unknown-linux-musl
+            arch: x86_64
+            executable: dotenv
+            apt: ''
+          - target: x86_64-pc-windows-gnu
+            archive: zip
+            platform: pc-windows-gnu
+            arch: x86_64
+            executable: dotenv.exe
+            apt: gcc-mingw-w64-x86-64
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Install system dependencies
+        if: matrix.apt != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ matrix.apt }}
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
+
+      - name: Build binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package asset
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.release_version }}
+          PLATFORM: ${{ matrix.platform }}
+          ARCH: ${{ matrix.arch }}
+          EXECUTABLE: ${{ matrix.executable }}
+          ARCHIVE: ${{ matrix.archive }}
+          TARGET: ${{ matrix.target }}
+        run: |
+          set -euo pipefail
+
+          version="${RELEASE_VERSION:-$(node -p "require('./package.json').version")}"
+          mkdir -p dist/release
+
+          asset_name="dotenv-cli-${version}-${PLATFORM}-${ARCH}.${ARCHIVE}"
+          binary_dir="target/${TARGET}/release"
+
+          if [ "$ARCHIVE" = "zip" ]; then
+            (cd "$binary_dir" && zip "$GITHUB_WORKSPACE/dist/release/$asset_name" "$EXECUTABLE")
+          else
+            tar -czf "dist/release/$asset_name" -C "$binary_dir" "$EXECUTABLE"
+          fi
+
+      - name: Upload packaged asset
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-asset-${{ matrix.target }}
+          path: dist/release/*
+          if-no-files-found: error
+
+  create-or-complete-release:
+    name: Create or complete release
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'release' && github.event.action == 'created')
+    needs: build-assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Download release assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-asset-*
+          path: dist/release
+          merge-multiple: true
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.release_version }}
+          RELEASE_TARGET: ${{ github.sha }}
+        run: devops/release/4-generate-release-notes.sh
+
+      - name: Create or complete release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.release_version }}
+          RELEASE_TARGET: ${{ github.sha }}
+          RELEASE_DRAFT: ${{ inputs.release_draft }}
+          PRERELEASE: ${{ inputs.release_prerelease }}
+          RELEASE_CLOBBER_ASSETS: ${{ inputs.clobber_assets }}
+        run: devops/release/5-create-github-release.sh
+
+  publish:
+    name: Publish packages
+    if: github.event_name == 'release' && github.event.action == 'published' && github.event.release.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Node for npm
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Install package dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Publish to npm
+        run: npm run publish:npm
+
+      - name: Set up Node for GitHub Packages
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://npm.pkg.github.com
+
+      - name: Publish to GitHub Packages
+        run: npm run publish:github
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 node_modules
 
 dotenv-*.tgz
-package-lock.json
 target

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dotenv-cli
 [![Version](https://img.shields.io/github/v/release/mikegarde/dotenv-cli)](https://github.com/MikeGarde/dotenv-cli)
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mikegarde/dotenv-cli/node.tests.yml)](https://github.com/MikeGarde/dotenv-cli/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mikegarde/dotenv-cli/test.rust.yml)](https://github.com/MikeGarde/dotenv-cli/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/mikegarde/dotenv-cli)](https://app.codecov.io/gh/MikeGarde/dotenv-cli)
 [![NPM Downloads](https://img.shields.io/npm/dy/%40mikegarde%2Fdotenv-cli?logo=npm&color=blue)](https://www.npmjs.com/package/@mikegarde/dotenv-cli)
 [![Crates.io Downloads](https://img.shields.io/crates/d/dotenv-cli?logo=crates&color=blue)](https://crates.io/crates/dotenv-cli)

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -12,21 +12,9 @@ tasks:
     status:
       - rustup target list --installed | grep -q x86_64-apple-darwin
       - rustup target list --installed | grep -q aarch64-apple-darwin
-      - rustup target list --installed | grep -q x86_64-unknown-linux-gnu
-      - rustup target list --installed | grep -q aarch64-unknown-linux-gnu
-      - rustup target list --installed | grep -q x86_64-unknown-linux-musl
-      - rustup target list --installed | grep -q aarch64-unknown-linux-musl
-      - rustup target list --installed | grep -q x86_64-pc-windows-msvc
-      - rustup target list --installed | grep -q aarch64-pc-windows-msvc
     cmds:
       - rustup target add x86_64-apple-darwin
       - rustup target add aarch64-apple-darwin
-      - rustup target add x86_64-unknown-linux-gnu
-      - rustup target add aarch64-unknown-linux-gnu
-      - rustup target add x86_64-unknown-linux-musl
-      - rustup target add aarch64-unknown-linux-musl
-      - rustup target add x86_64-pc-windows-msvc
-      - rustup target add aarch64-pc-windows-msvc
 
   test:
     desc: "Run all tests"
@@ -67,7 +55,7 @@ tasks:
     desc: Local development setup
     cmds:
       - task: uninstall
-      - npm install -g @mikegarde/dotenv-cli
+      - npm install -g @mikegarde/dotenv-cli@0.6.1
   uninstall:
     desc: "Uninstall all local installations of dotenv-cli (cargo, npm, brew)"
     internal: true
@@ -102,7 +90,7 @@ tasks:
       - devops/release/1-bump-version.sh {{.STEP}}
       - task test
       - devops/release/2-tag-version.sh
-      - task release:assets
+      - devops/release/3-build-release-assets.sh --macos
       - devops/release/4-generate-release-notes.sh
       - devops/release/5-create-github-release.sh
   publish:

--- a/devops/release/1-bump-version.sh
+++ b/devops/release/1-bump-version.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+source "$SCRIPT_DIR/release-config.sh"
+
+STEP="${1:-}"
+
+case "$STEP" in
+  patch|minor|major|[0-9]*.[0-9]*.[0-9]*) ;;
+  *)
+    echo 'Usage: devops/release/1-bump-version.sh <patch|minor|major|x.y.z>' >&2
+    exit 1
+    ;;
+esac
+
+CURRENT_VERSION="$(package_version)"
+
+if printf '%s\n' "$STEP" | grep -Eq '^[v]?[0-9]+\.[0-9]+\.[0-9]+'; then
+  NEXT_VERSION="${STEP#v}"
+else
+  major="$(printf '%s\n' "$CURRENT_VERSION" | cut -d. -f1)"
+  minor="$(printf '%s\n' "$CURRENT_VERSION" | cut -d. -f2)"
+  patch="$(printf '%s\n' "$CURRENT_VERSION" | cut -d. -f3)"
+
+  case "$STEP" in
+    major) NEXT_VERSION="$((major + 1)).0.0" ;;
+    minor) NEXT_VERSION="$major.$((minor + 1)).0" ;;
+    patch) NEXT_VERSION="$major.$minor.$((patch + 1))" ;;
+  esac
+fi
+
+awk -v version="$NEXT_VERSION" '
+  !done && /"version": "/ {
+    sub(/"version": "[^"]*"/, "\"version\": \"" version "\"")
+    done = 1
+  }
+  { print }
+' package.json > package.json.tmp
+mv package.json.tmp package.json
+
+awk -v version="$NEXT_VERSION" '
+  !done && /^version = "/ {
+    print "version = \"" version "\""
+    done = 1
+    next
+  }
+  { print }
+' Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
+
+echo "$NEXT_VERSION"

--- a/devops/release/2-tag-version.sh
+++ b/devops/release/2-tag-version.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+source "$SCRIPT_DIR/release-config.sh"
+
+COMMIT=true
+
+case "${1:-}" in
+  '')
+    ;;
+  --no-commit)
+    COMMIT=false
+    ;;
+  -h|--help)
+    echo 'Usage: devops/release/2-tag-version.sh [--no-commit]'
+    exit 0
+    ;;
+  *)
+    echo 'Usage: devops/release/2-tag-version.sh [--no-commit]' >&2
+    exit 1
+    ;;
+esac
+
+TAG_NAME="$(package_version)"
+
+if [ "$COMMIT" = true ]; then
+  git add package.json package-lock.json Cargo.toml Cargo.lock
+
+  if ! git diff --cached --quiet; then
+    git commit -m "chore: release $TAG_NAME"
+  fi
+fi
+
+git tag "$TAG_NAME"
+git push --follow-tags

--- a/devops/release/3-build-release-assets.sh
+++ b/devops/release/3-build-release-assets.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+source "$SCRIPT_DIR/release-config.sh"
+
+DIST_DIR="$REPO_ROOT/dist/release"
+VERSION="${RELEASE_VERSION:-$(package_version)}"
+
+mkdir -p "$DIST_DIR"
+
+selected_targets() {
+  if [ "${1:-}" = "--all" ]; then
+    release_targets
+    return
+  fi
+
+  if [ "${1:-}" = "--macos" ]; then
+    release_targets | awk -F'|' '$4 == "apple-darwin" { print }'
+    return
+  fi
+
+  if [ "${1:-}" = "--no-macos" ]; then
+    release_targets | awk -F'|' '$4 != "apple-darwin" { print }'
+    return
+  fi
+
+  if [ -n "${RELEASE_TARGETS:-}" ]; then
+    IFS=',' read -r -a requested_targets <<< "$RELEASE_TARGETS"
+    targets_matching "${requested_targets[@]}"
+    return
+  fi
+
+  if [ "$#" -gt 0 ]; then
+    targets_matching "$@"
+    return
+  fi
+
+  local platform arch
+  case "$(uname -s)" in
+    Darwin) platform='apple-darwin' ;;
+    Linux) platform='unknown-linux-gnu' ;;
+    MINGW*|MSYS*|CYGWIN*) platform='pc-windows-msvc' ;;
+    *) echo "Unsupported platform: $(uname -s)" >&2; exit 1 ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch='x86_64' ;;
+    arm64|aarch64) arch='aarch64' ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+
+  release_targets | awk -F'|' -v platform="$platform" -v arch="$arch" \
+    '$4 == platform && $5 == arch { print }'
+}
+
+targets_matching() {
+  local requested rust_target target
+
+  for target in "${TARGET_ROWS[@]}"; do
+    IFS='|' read -r _os _cpu rust_target _platform _arch _executable <<< "$target"
+
+    for requested in "$@"; do
+      if [[ "$requested" == "$rust_target" ]]; then
+        printf '%s\n' "$target"
+      fi
+    done
+  done
+}
+
+mapfile -t targets < <(selected_targets "$@")
+
+if [ "${#targets[@]}" -eq 0 ]; then
+  echo 'No matching release targets selected.' >&2
+  exit 1
+fi
+
+for target in "${targets[@]}"; do
+  IFS='|' read -r os cpu rust_target platform arch executable <<< "$target"
+
+  echo "Building $rust_target"
+  cargo build --release --target "$rust_target"
+
+  binary_dir="$REPO_ROOT/target/$rust_target/release"
+  archive_path="$DIST_DIR/$(asset_name "$VERSION" "$platform" "$arch")"
+
+  tar -czf "$archive_path" -C "$binary_dir" "$executable"
+  echo "Wrote $archive_path"
+done

--- a/devops/release/4-generate-release-notes.sh
+++ b/devops/release/4-generate-release-notes.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+source "$SCRIPT_DIR/release-config.sh"
+
+command -v jq >/dev/null 2>&1 || {
+  echo 'jq is required to parse GitHub release-note JSON.' >&2
+  exit 1
+}
+
+DIST_DIR="$REPO_ROOT/dist/release"
+TEMPLATE_FILE="$REPO_ROOT/devops/templates/release-notes.md"
+VERSION="${RELEASE_VERSION:-$(package_version)}"
+TARGET_COMMITISH="${RELEASE_TARGET:-$(current_branch)}"
+REPO="${RELEASE_REPO:-$(github_repo)}"
+RESPONSE_FILE="$DIST_DIR/release-notes.response.json"
+BODY_FILE="$DIST_DIR/release-notes-body.md"
+LINK_MATRIX_FILE="$DIST_DIR/release-notes-link-matrix.md"
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+  echo "Release notes template not found: $TEMPLATE_FILE" >&2
+  exit 1
+fi
+
+mkdir -p "$DIST_DIR"
+
+args=(
+  "repos/$REPO/releases/generate-notes"
+  --method POST
+  -f "tag_name=$VERSION"
+  -f "target_commitish=$TARGET_COMMITISH"
+)
+
+if [ -n "${PREVIOUS_TAG:-}" ]; then
+  args+=(-f "previous_tag_name=$PREVIOUS_TAG")
+fi
+
+gh api "${args[@]}" > "$RESPONSE_FILE"
+
+jq -r '.name' "$RESPONSE_FILE" > "$DIST_DIR/release-notes-title.txt"
+jq -r '.body' "$RESPONSE_FILE" > "$BODY_FILE"
+
+{
+  declare -A intel_links=()
+  declare -A arm_links=()
+
+  for target in "${TARGET_ROWS[@]}"; do
+    IFS='|' read -r os cpu rust_target platform arch executable <<< "$target"
+    name="$(asset_name "$VERSION" "$platform" "$arch")"
+    url="https://github.com/$REPO/releases/download/$VERSION/$name"
+    link="[$arch]($url)"
+
+    if [ "$cpu" = 'Intel' ]; then
+      intel_links["$os"]="$link"
+    else
+      arm_links["$os"]="$link"
+    fi
+  done
+
+  for os_name in "${OS_ORDER[@]}"; do
+    printf '| %s | %s | %s |\n' \
+      "$os_name" \
+      "${intel_links[$os_name]:--}" \
+      "${arm_links[$os_name]:--}"
+  done
+} > "$LINK_MATRIX_FILE"
+
+awk \
+  -v notes_file="$BODY_FILE" \
+  -v link_matrix_file="$LINK_MATRIX_FILE" \
+  '
+    $0 == "{NOTES}" {
+      while ((getline line < notes_file) > 0) print line
+      close(notes_file)
+      next
+    }
+
+    $0 == "{LINK_MATRIX}" {
+      while ((getline line < link_matrix_file) > 0) print line
+      close(link_matrix_file)
+      next
+    }
+
+    { print }
+  ' "$TEMPLATE_FILE" > "$DIST_DIR/release-notes.md"
+
+perl -pi -e "s/\{VERSION\}/${VERSION}/g" "$DIST_DIR/release-notes.md"
+
+echo "Wrote $DIST_DIR/release-notes.md"
+echo "Wrote $DIST_DIR/release-notes-title.txt"

--- a/devops/release/5-create-github-release.sh
+++ b/devops/release/5-create-github-release.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+cd "$REPO_ROOT"
+source "$SCRIPT_DIR/release-config.sh"
+
+DIST_DIR="$REPO_ROOT/dist/release"
+VERSION="${RELEASE_VERSION:-$(package_version)}"
+TAG_NAME="$VERSION"
+TARGET_COMMITISH="${RELEASE_TARGET:-$(current_branch)}"
+NOTES_FILE="$DIST_DIR/release-notes.md"
+TITLE_FILE="$DIST_DIR/release-notes-title.txt"
+ASSET_PATTERNS=(
+  "$DIST_DIR"/*.tar.gz
+  "$DIST_DIR"/*.tar.xz
+  "$DIST_DIR"/*.tar.zst
+  "$DIST_DIR"/*.zip
+)
+
+assets=()
+for asset in "${ASSET_PATTERNS[@]}"; do
+  if [ -f "$asset" ]; then
+    assets+=("$asset")
+  fi
+done
+
+if [ "${#assets[@]}" -eq 0 ]; then
+  echo 'No release assets found. Run task release:assets first.' >&2
+  exit 1
+fi
+
+upload_args=(
+  release upload "$TAG_NAME"
+  "${assets[@]}"
+)
+
+if [ "${RELEASE_CLOBBER_ASSETS:-false}" = 'true' ]; then
+  upload_args+=(--clobber)
+fi
+
+if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+  if [ "${RELEASE_CLOBBER_ASSETS:-false}" != 'true' ]; then
+    mapfile -t existing_assets < <(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')
+    missing_assets=()
+
+    for asset in "${assets[@]}"; do
+      local_asset_name="$(basename "$asset")"
+      already_uploaded=false
+
+      for existing_asset in "${existing_assets[@]}"; do
+        if [ "$local_asset_name" = "$existing_asset" ]; then
+          already_uploaded=true
+          break
+        fi
+      done
+
+      if [ "$already_uploaded" = false ]; then
+        missing_assets+=("$asset")
+      fi
+    done
+
+    if [ "${#missing_assets[@]}" -eq 0 ]; then
+      echo "Release $TAG_NAME already has all local assets."
+      exit 0
+    fi
+
+    upload_args=(
+      release upload "$TAG_NAME"
+      "${missing_assets[@]}"
+    )
+  fi
+
+  gh "${upload_args[@]}"
+  exit 0
+fi
+
+if [ ! -f "$NOTES_FILE" ] || [ ! -f "$TITLE_FILE" ]; then
+  echo 'Release notes are missing. Run devops/release/4-generate-release-notes.sh first.' >&2
+  exit 1
+fi
+
+args=(
+  release create "$TAG_NAME"
+  "${assets[@]}"
+  --title "$(cat "$TITLE_FILE")"
+  --notes-file "$NOTES_FILE"
+  --target "$TARGET_COMMITISH"
+)
+
+if [ "$TARGET_COMMITISH" = 'develop' ] || [ "${PRERELEASE:-false}" = 'true' ]; then
+  args+=(--prerelease)
+fi
+
+if [ "${RELEASE_DRAFT:-true}" != 'false' ]; then
+  args+=(--draft)
+fi
+
+gh "${args[@]}"

--- a/devops/release/release-config.sh
+++ b/devops/release/release-config.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+PACKAGE_NAME='@mikegarde/dotenv-cli'
+BINARY_NAME='dotenv'
+OS_ORDER=('macOS' 'Linux glibc' 'Linux static' 'Windows')
+TARGET_ROWS=(
+  'macOS|Intel|x86_64-apple-darwin|apple-darwin|x86_64|dotenv'
+  'macOS|Arm|aarch64-apple-darwin|apple-darwin|aarch64|dotenv'
+  'Linux glibc|Intel|x86_64-unknown-linux-gnu|unknown-linux-gnu|x86_64|dotenv'
+  'Linux glibc|Arm|aarch64-unknown-linux-gnu|unknown-linux-gnu|aarch64|dotenv'
+  'Linux static|Intel|x86_64-unknown-linux-musl|unknown-linux-musl|x86_64|dotenv'
+  'Linux static|Arm|aarch64-unknown-linux-musl|unknown-linux-musl|aarch64|dotenv'
+  'Windows|Intel|x86_64-pc-windows-msvc|pc-windows-msvc|x86_64|dotenv.exe'
+  'Windows|Arm|aarch64-pc-windows-msvc|pc-windows-msvc|aarch64|dotenv.exe'
+)
+
+require_bash_5() {
+  if [ -z "${BASH_VERSION:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 5 ]; then
+    echo 'Release scripts require Bash 5.x or newer.' >&2
+    echo 'On macOS, install modern Bash with Homebrew and run these scripts with that bash.' >&2
+    exit 1
+  fi
+}
+
+release_targets() {
+  printf '%s\n' "${TARGET_ROWS[@]}"
+}
+
+asset_name() {
+  local version="$1"
+  local platform="$2"
+  local arch="$3"
+
+  printf 'dotenv-cli-%s-%s-%s.tar.gz\n' "$version" "$platform" "$arch"
+}
+
+package_version() {
+  sed -n 's/.*"version": "\([^"]*\)".*/\1/p' package.json | head -n 1
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+github_repo() {
+  gh repo view --json nameWithOwner --jq '.nameWithOwner'
+}
+
+require_bash_5

--- a/devops/templates/release-notes.md
+++ b/devops/templates/release-notes.md
@@ -1,0 +1,43 @@
+{NOTES}
+
+## Install
+
+### MacOS (brew)
+
+```bash
+brew install mikegarde/tap/dotenv-cli
+```
+
+### Node
+
+```bash
+npm i -g @mikegarde/dotenv-cli
+```
+
+## Download
+
+Download the appropriate archive for your platform, extract it, and place the `dotenv` binary somewhere in your system `PATH`.
+
+| OS | Intel | Arm |
+| --- | --- | --- |
+{LINK_MATRIX}
+
+### Linux
+
+For most distributions, the `glibc` build is correct. Use the `musl` build for Alpine Linux or fully static environments.
+
+```bash
+# Download and extract
+curl -L https://github.com/MikeGarde/dotenv-cli/releases/download/{VERSION}/dotenv-cli-{VERSION}-unknown-linux-gnu-x86_64.tar.gz \
+  | tar -xz
+
+# Make executable
+chmod +x dotenv
+
+# Move into PATH
+sudo mv dotenv /usr/local/bin/dotenv
+```
+
+### Windows
+
+Download the appropriate archive, extract `dotenv.exe`, and place it in a directory already included in your `PATH`.

--- a/postinstall.js
+++ b/postinstall.js
@@ -40,7 +40,7 @@ function getAssetName() {
 }
 
 function getDownloadUrl() {
-  return `https://github.com/${repo}/releases/download/v${version}/${getAssetName()}`;
+  return `https://github.com/${repo}/releases/download/${version}/${getAssetName()}`;
 }
 
 function getVendorDir() {


### PR DESCRIPTION
Automates versioning, tagging, asset builds, release notes, and publishing.

- Adds release-config.sh for centralized metadata and cross-platform target matrix.
- Introduces a release script suite (devops/release/1-5) to automate bump, tag, asset packaging, notes, and GitHub release creation.
- Implements build-release-assets.sh to generate versioned tarballs for multiple targets under dist/release.
- Adds generate-release-notes.sh to fetch/generate release notes and output artifacts under dist/release.
- Provides create-github-release.sh to create/update releases and idempotently upload assets.
- Adds a release notes template at devops/templates/release-notes.md for standardized content.
- Fixes postinstall.js to correct the GitHub release URL path.
- Updates Taskfile.yaml to pin dotenv-cli and align with macOS-focused builds.
- Updates .gitignore to stop ignoring key packaging artifacts (node_modules, dotenv-*.tgz, package-lock.json).
- Updates README.md to reflect the renamed workflow badge (test.rust.yml).
- Enables publishing of npm/GitHub Packages as part of the release process.