### PR TITLE
Improve stdin handling for piped inputs using set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,6 @@ dependencies = [
  "assert_cmd",
  "clap",
  "indexmap",
- "is-terminal",
  "predicates",
  "serde_json",
  "sha2",
@@ -270,12 +269,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,17 +285,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 indexmap = "2"
-is-terminal = "0.4"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ dotenv <key> --set <value>
 Or pipe a value in:
 
 ```shell
-echo <value> | dotenv <key>
+echo <value> | dotenv <key> --set -
 ```
+
+> A plain `dotenv <key>` always *reads* and never consumes stdin, so it's safe
+> to call inside scripts and pipelines. Writing from stdin requires the explicit
+> `--set -`.
 
 ### Deleting a Value
 
@@ -70,8 +74,8 @@ dotenv <key> --delete
 2. **Public Key** The `dotenv` command, with the `--multiline` flag, retrieves the stored private key and pipes it back to openssl. `openssl` then generates a corresponding public key. This public key is stored in the `.env` file under the variable `RSA_PUB`.
 
 ```shell
-openssl genpkey -algorithm RSA -outform PEM -pkeyopt rsa_keygen_bits:2048 2>/dev/null | dotenv RSA_KEY
-dotenv RSA_KEY -m | openssl rsa -pubout 2>/dev/null | dotenv RSA_PUB
+openssl genpkey -algorithm RSA -outform PEM -pkeyopt rsa_keygen_bits:2048 2>/dev/null | dotenv RSA_KEY --set -
+dotenv RSA_KEY -m | openssl rsa -pubout 2>/dev/null | dotenv RSA_PUB --set -
 ```
 
 ### App Version

--- a/devops/render-release-notes.sh
+++ b/devops/render-release-notes.sh
@@ -20,19 +20,22 @@ cat <<EOF
 brew install mikegarde/tap/dotenv-cli
 \`\`\`
 
-### npm
+### NPM
 
 \`\`\`bash
 npm install -g @mikegarde/dotenv-cli
 \`\`\`
 
-## Install on RHEL
+### Manual
+
+RHEL x86
 
 \`\`\`bash
-# x86
 curl -fsSL "https://github.com/MikeGarde/dotenv-cli/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-x86_64.tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin dotenv
+\`\`\`
 
-# arm
+RHEL arm
+\`\`\`bash
 curl -fsSL "https://github.com/MikeGarde/dotenv-cli/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-aarch64.tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin dotenv
 \`\`\`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,11 @@ pub struct Cli {
     #[arg(short, long, action = ArgAction::SetTrue, help = "Allow multiline values")]
     pub multiline: bool,
 
-    #[arg(short, long, help = "Update the environment variable in the .env file")]
+    #[arg(
+        short,
+        long,
+        help = "Update the environment variable in the .env file (use `--set -` to read the value from stdin)"
+    )]
     pub set: Option<String>,
 
     #[arg(short = 'D', long, action = ArgAction::SetTrue, help = "Delete the environment variable from the .env file")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,12 @@ fn run() -> Result<i32, Box<dyn std::error::Error>> {
     let delete = cli.delete;
     let keys = cli.key.clone();
 
-    // Read stdin before any other I/O
-    let stdin_value = read_pipe::read_pipe();
-    let set_opt = cli.set.clone();
-
-    if stdin_value.is_some() && set_opt.is_some() {
-        return Err(Box::new(RuleViolationError(
-            "Cannot use --set and stdin together".to_string(),
-        )));
-    }
-
-    let set_value_raw = stdin_value.or(set_opt);
+    // `--set -` is the explicit opt-in to read the value from stdin. Without it,
+    // stdin is never touched, so reading a key can never consume a caller's stdin.
+    let set_value_raw = match cli.set.clone() {
+        Some(v) if v == "-" => Some(read_pipe::read_stdin()),
+        other => other,
+    };
     let is_set = set_value_raw.is_some();
 
     let env_file = cli

--- a/src/read_pipe.rs
+++ b/src/read_pipe.rs
@@ -1,18 +1,13 @@
-use is_terminal::IsTerminal;
 use std::io::{self, Read};
 
-/// Read all piped stdin and return it trimmed, or `None` when stdin is a TTY
-/// (i.e. no pipe is present).
-pub fn read_pipe() -> Option<String> {
-    if io::stdin().is_terminal() {
-        return None;
-    }
+/// Read all of stdin and return it trimmed.
+///
+/// Called only when the user explicitly opts into stdin with `--set -`, so this
+/// never inspects whether stdin is a TTY: reading is always an explicit request.
+pub fn read_stdin() -> String {
     let mut input = String::new();
-    io::stdin().read_to_string(&mut input).ok()?;
-    let trimmed = input.trim().to_string();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed)
-    }
+    io::stdin()
+        .read_to_string(&mut input)
+        .expect("Failed to read from stdin");
+    input.trim().to_string()
 }

--- a/tests/set_and_delete.rs
+++ b/tests/set_and_delete.rs
@@ -113,9 +113,11 @@ fn update_existing_key() {
 #[test]
 fn update_existing_key_with_stdin() {
     let tmp = copy_env();
-    // Use assert_cmd::Command to test stdin input
+    // `--set -` opts into reading the value from stdin
     bin()
         .arg("NEW_TWO")
+        .arg("--set")
+        .arg("-")
         .arg("--file")
         .arg(tmp.path())
         .write_stdin("New stdin value")
@@ -128,6 +130,28 @@ fn update_existing_key_with_stdin() {
         .assert()
         .success()
         .stdout("New stdin value\n");
+}
+
+#[test]
+fn read_ignores_piped_stdin() {
+    // A plain read must never consume stdin, even when something is piped in.
+    let tmp = copy_env();
+    bin()
+        .arg("NEW_ONE")
+        .arg("--set")
+        .arg("Single line value")
+        .arg("--file")
+        .arg(tmp.path())
+        .assert()
+        .success();
+    bin()
+        .arg("NEW_ONE")
+        .arg("--file")
+        .arg(tmp.path())
+        .write_stdin("this should be ignored")
+        .assert()
+        .success()
+        .stdout("Single line value\n");
 }
 
 #[test]
@@ -289,6 +313,8 @@ fn chained_set_update_delete_workflow_preserves_file() {
 
     bin()
         .arg("NEW_TWO")
+        .arg("--set")
+        .arg("-")
         .arg("--file")
         .arg(tmp.path())
         .write_stdin("New stdin value")


### PR DESCRIPTION
- Refactors argument parsing to robustly consume standard input when piping data via `--set -`.
- Simplifies input reading logic by removing TTY checks in `src/read_pipe.rs`.
- Updates documentation (README) to clarify the mandatory use of `--set -` for stdin consumption.
- Cleans up dependencies and updates devops release notes clarity.