### PR TITLE
Migrate packaging from tarballs to gzip binaries

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -110,12 +110,12 @@ jobs:
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: ${{ matrix.target == 'x86_64-unknown-linux-musl' && matrix.linker || '' }}
         run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Package tar.gz archive
+      - name: Compress release binary
         shell: bash
         run: |
           set -euo pipefail
-          asset="dotenv-cli-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.tar.gz"
-          tar -C "target/${{ matrix.target }}/release" -czf "$asset" "${{ matrix.binary_name }}"
+          asset="dotenv-cli-${{ steps.meta.outputs.tag }}-${{ matrix.asset_target }}.gz"
+          gzip -n -c "target/${{ matrix.target }}/release/${{ matrix.binary_name }}" > "$asset"
           echo "ASSET_PATH=$asset" >> "$GITHUB_ENV"
 
       - name: Upload asset to GitHub release

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Find it on
 brew install mikegarde/tap/dotenv-cli
 
 # Using npm (Node.js)
-npm i -g @mikegarde/dotenv-cli
+npm i -g @mikegarde/dotenv-cli --allow-scripts=@mikegarde/dotenv-cli
 
 # Using Cargo (Rust)
 cargo install dotenv-cli

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -43,7 +43,7 @@ tasks:
     silent: true
     cmds:
       - mkdir -p dist
-      - rm -f dist/dotenv-cli-*.tar.gz
+      - rm -f dist/dotenv-cli-*.gz
       - |
         set -euo pipefail
 
@@ -56,13 +56,11 @@ tasks:
 
         echo "Packaging into dist with version {{.VERSION}}..."
 
-        tar -C target/aarch64-apple-darwin/release \
-          -czf dist/dotenv-cli-{{.VERSION}}-apple-darwin-aarch64.tar.gz \
-          dotenv
+        gzip -n -c target/aarch64-apple-darwin/release/dotenv \
+          > dist/dotenv-cli-{{.VERSION}}-apple-darwin-aarch64.gz
 
-        tar -C target/x86_64-apple-darwin/release \
-          -czf dist/dotenv-cli-{{.VERSION}}-apple-darwin-x86_64.tar.gz \
-          dotenv
+        gzip -n -c target/x86_64-apple-darwin/release/dotenv \
+          > dist/dotenv-cli-{{.VERSION}}-apple-darwin-x86_64.gz
 
         echo "Artifacts created:"
         ls -lh dist

--- a/devops/publish-if-complete.sh
+++ b/devops/publish-if-complete.sh
@@ -5,13 +5,13 @@ set -euo pipefail
 TAG="${1:?usage: publish-if-complete.sh <tag>}"
 
 EXPECTED=(
-  "dotenv-cli-${TAG}-apple-darwin-aarch64.tar.gz"
-  "dotenv-cli-${TAG}-apple-darwin-x86_64.tar.gz"
-  "dotenv-cli-${TAG}-unknown-linux-gnu-aarch64.tar.gz"
-  "dotenv-cli-${TAG}-unknown-linux-gnu-x86_64.tar.gz"
-  "dotenv-cli-${TAG}-unknown-linux-musl-aarch64.tar.gz"
-  "dotenv-cli-${TAG}-unknown-linux-musl-x86_64.tar.gz"
-  "dotenv-cli-${TAG}-pc-windows-gnu-x86_64.tar.gz"
+  "dotenv-cli-${TAG}-apple-darwin-aarch64.gz"
+  "dotenv-cli-${TAG}-apple-darwin-x86_64.gz"
+  "dotenv-cli-${TAG}-unknown-linux-gnu-aarch64.gz"
+  "dotenv-cli-${TAG}-unknown-linux-gnu-x86_64.gz"
+  "dotenv-cli-${TAG}-unknown-linux-musl-aarch64.gz"
+  "dotenv-cli-${TAG}-unknown-linux-musl-x86_64.gz"
+  "dotenv-cli-${TAG}-pc-windows-gnu-x86_64.gz"
 )
 
 ACTUAL="$(gh release view "${TAG}" --json assets --jq '[.assets[].name]')"

--- a/devops/release.sh
+++ b/devops/release.sh
@@ -128,7 +128,7 @@ if git rev-parse -q --verify "refs/tags/$NEW_VERSION" >/dev/null 2>&1; then
   task setup
   task "build:release:${NEW_VERSION}"
 
-  MAC_ASSETS=("$DIST_DIR"/dotenv-cli-"$NEW_VERSION"-*apple-darwin*.tar.gz)
+  MAC_ASSETS=("$DIST_DIR"/dotenv-cli-"$NEW_VERSION"-*apple-darwin*.gz)
   if [ ${#MAC_ASSETS[@]} -eq 0 ]; then
     echo "Error: no macOS assets found in $DIST_DIR after build."
     exit 1
@@ -219,7 +219,7 @@ if [ ! -d "$DIST_DIR" ]; then
   exit 1
 fi
 
-MAC_ASSETS=("$DIST_DIR"/dotenv-cli-"$NEW_VERSION"-*apple-darwin*.tar.gz)
+MAC_ASSETS=("$DIST_DIR"/dotenv-cli-"$NEW_VERSION"-*apple-darwin*.gz)
 if [ ${#MAC_ASSETS[@]} -eq 0 ]; then
   echo "Error: no macOS assets found in '$DIST_DIR'."
   exit 1

--- a/devops/render-release-notes.sh
+++ b/devops/render-release-notes.sh
@@ -31,12 +31,14 @@ npm install -g @mikegarde/dotenv-cli
 RHEL x86
 
 \`\`\`bash
-curl -fsSL "https://github.com/MikeGarde/dotenv-cli/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-x86_64.tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin dotenv
+curl -fsSL "$(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-x86_64.gz")" | gzip -dc | sudo tee /usr/local/bin/dotenv >/dev/null
+sudo chmod 0755 /usr/local/bin/dotenv
 \`\`\`
 
 RHEL arm
 \`\`\`bash
-curl -fsSL "https://github.com/MikeGarde/dotenv-cli/releases/download/${VERSION}/commitbot-${VERSION}-unknown-linux-musl-aarch64.tar.gz" | sudo tar -xz --no-same-owner -C /usr/local/bin dotenv
+curl -fsSL "$(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-aarch64.gz")" | gzip -dc | sudo tee /usr/local/bin/dotenv >/dev/null
+sudo chmod 0755 /usr/local/bin/dotenv
 \`\`\`
 
 
@@ -44,10 +46,10 @@ curl -fsSL "https://github.com/MikeGarde/dotenv-cli/releases/download/${VERSION}
 
 | OS | arm64 | x86_64 |
 | --- | --- | --- |
-| macOS | [Download]($(asset_url "dotenv-cli-${VERSION}-apple-darwin-aarch64.tar.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-apple-darwin-x86_64.tar.gz")) |
-| Ubuntu | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-gnu-aarch64.tar.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-gnu-x86_64.tar.gz")) |
-| RHEL | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-aarch64.tar.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-x86_64.tar.gz")) |
-| Windows | — | [Download]($(asset_url "dotenv-cli-${VERSION}-pc-windows-gnu-x86_64.tar.gz")) |
+| macOS | [Download]($(asset_url "dotenv-cli-${VERSION}-apple-darwin-aarch64.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-apple-darwin-x86_64.gz")) |
+| Ubuntu | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-gnu-aarch64.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-gnu-x86_64.gz")) |
+| RHEL | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-aarch64.gz")) | [Download]($(asset_url "dotenv-cli-${VERSION}-unknown-linux-musl-x86_64.gz")) |
+| Windows | — | [Download]($(asset_url "dotenv-cli-${VERSION}-pc-windows-gnu-x86_64.gz")) |
 
 - Ubuntu and compatible distributions like Debian, Mint, etc. that use glibc.
 - RHEL and compatible distributions like Amazon, Rocky, etc. that use musl instead of glibc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,79 +9,9 @@
       "version": "1.1.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
-      "dependencies": {
-        "tar": "^7.5.13"
-      },
       "bin": {
         "dotenv": "bin/dotenv"
       },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/tar": {
-      "version": "7.5.19",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
-      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
   "bugs": {
     "url": "https://github.com/MikeGarde/dotenv-cli/issues"
   },
-  "homepage": "https://github.com/MikeGarde/dotenv-cli#readme",
-  "dependencies": {
-    "tar": "^7.5.13"
-  }
+  "homepage": "https://github.com/MikeGarde/dotenv-cli#readme"
 }

--- a/postinstall.js
+++ b/postinstall.js
@@ -4,8 +4,10 @@ import https from 'https';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { pipeline } from 'stream/promises';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { createGunzip } from 'zlib';
 
 const require = createRequire(import.meta.url);
 const version = require('./package.json').version;
@@ -13,10 +15,6 @@ const repo = 'MikeGarde/dotenv-cli';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-// For tar, use dynamic import:
-
-
 
 function getPlatform() {
   switch (process.platform) {
@@ -36,7 +34,7 @@ function getArch() {
 }
 
 function getAssetName() {
-  return `dotenv-cli-${version}-${getPlatform()}-${getArch()}.tar.gz`;
+  return `dotenv-cli-${version}-${getPlatform()}-${getArch()}.gz`;
 }
 
 function getDownloadUrl() {
@@ -55,15 +53,27 @@ function getBinPath() {
   return path.join(getVendorDir(), getBinName());
 }
 
-async function downloadAndExtract(url, destDir, binName) {
-  const tar = await import('tar');
+async function downloadAndInstall(url, destDir, binName) {
   if (!fs.existsSync(destDir)) fs.mkdirSync(destDir, { recursive: true });
-  const tmpFile = path.join(os.tmpdir(), `dotenv-cli-${Date.now()}.tar.gz`);
-  await download(url, tmpFile);
-  await tar.x({ file: tmpFile, cwd: destDir });
-  fs.chmodSync(path.join(destDir, binName), 0o755);
-  fs.unlinkSync(tmpFile);
-  console.log(`Installed dotenv binary to ${path.join(destDir, binName)}`);
+  const tmpFile = path.join(os.tmpdir(), `dotenv-cli-${Date.now()}.gz`);
+  const binPath = path.join(destDir, binName);
+
+  try {
+    await download(url, tmpFile);
+    await pipeline(
+      fs.createReadStream(tmpFile),
+      createGunzip(),
+      fs.createWriteStream(binPath),
+    );
+    fs.chmodSync(binPath, 0o755);
+  } catch (error) {
+    fs.rmSync(binPath, { force: true });
+    throw error;
+  } finally {
+    fs.rmSync(tmpFile, { force: true });
+  }
+
+  console.log(`Installed dotenv binary to ${binPath}`);
 }
 
 function download(url, tmpFile, redirectCount = 0) {
@@ -105,7 +115,7 @@ async function main() {
 
   const binDir = getVendorDir();
   const url = getDownloadUrl();
-  await downloadAndExtract(url, binDir, getBinName());
+  await downloadAndInstall(url, binDir, getBinName());
 }
 
 main().catch((err) => {


### PR DESCRIPTION
- Switch packaging from tar.gz to a single `.gz` binary; update asset naming, generation, and cleanup to `.gz`.
- Update release and publish scripts to detect and download `.gz` assets, gzip-decompress them, and install the binary to `/usr/local/bin`.
- Remove tar tooling from dependencies and code (`package.json`, `package-lock.json`, `postinstall.js`); simplify to use `.gz` artifacts throughout.
- Update README to note that `npm install` requires `--allow-scripts` due to install scripts.