### PR TITLE
Add cycle-detection for nested env vars

### DIFF
--- a/src/env_object.rs
+++ b/src/env_object.rs
@@ -76,9 +76,13 @@ impl EnvObject {
     }
 
     fn resolve_value(&self, input: &str) -> String {
+        // A circular reference (e.g. A=${B}, B=${A}) oscillates between the same
+        // few strings forever instead of converging, so track seen states and
+        // bail out on a repeat rather than looping indefinitely.
         let mut result = input.to_string();
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(result.clone());
         loop {
-            let prev = result.clone();
             let mut new_result = String::new();
             let mut chars = result.chars().peekable();
             while let Some(c) = chars.next() {
@@ -100,10 +104,11 @@ impl EnvObject {
                     new_result.push(c);
                 }
             }
-            result = new_result;
-            if result == prev {
+            if new_result == result || !seen.insert(new_result.clone()) {
+                result = new_result;
                 break;
             }
+            result = new_result;
         }
         result
     }

--- a/tests/resolve_nested_variables.rs
+++ b/tests/resolve_nested_variables.rs
@@ -52,3 +52,38 @@ fn resolve_merged_value() {
     env.resolve_nested_variables();
     assert_eq!(env.get("VAR3").unwrap().value, "Hello World & Universe");
 }
+
+#[test]
+fn resolve_circular_reference_terminates() {
+    let mut env = EnvObject::new();
+    env.set(
+        "VAR_A".to_string(),
+        EnvValue::with_lines("${VAR_B}".to_string(), 0, 0),
+    );
+    env.set(
+        "VAR_B".to_string(),
+        EnvValue::with_lines("${VAR_A}".to_string(), 1, 1),
+    );
+    env.resolve_nested_variables();
+    assert!(env.get("VAR_A").unwrap().value.contains("${"));
+    assert!(env.get("VAR_B").unwrap().value.contains("${"));
+}
+
+#[test]
+fn resolve_three_way_circular_reference_terminates() {
+    let mut env = EnvObject::new();
+    env.set(
+        "VAR_A".to_string(),
+        EnvValue::with_lines("${VAR_B}".to_string(), 0, 0),
+    );
+    env.set(
+        "VAR_B".to_string(),
+        EnvValue::with_lines("${VAR_C}".to_string(), 1, 1),
+    );
+    env.set(
+        "VAR_C".to_string(),
+        EnvValue::with_lines("${VAR_A}".to_string(), 2, 2),
+    );
+    env.resolve_nested_variables();
+    assert!(env.get("VAR_A").unwrap().value.contains("${"));
+}


### PR DESCRIPTION
- Implement cycle detection in `resolve_value` by tracking seen results with a `HashSet`, seeded with the initial input to catch oscillations like `A=${B}` / `B=${A}`.
- Replace the per-iteration previous-value check with a set-based bailout that stops when the new result is the same as the current one or has already been seen, ensuring safe termination.
- Extend tests in `tests/resolve_nested_variables.rs` to cover circular dependencies, verifying two-way and three-way references terminate and leave unresolved placeholders intact (contain `${`), i.e., graceful degradation.