### PR TITLE
Preserve newlines in values by quoting

### DIFF
--- a/src/handlers/set_value.rs
+++ b/src/handlers/set_value.rs
@@ -11,7 +11,11 @@ use crate::qualifying_rules::Options;
 pub fn set_value(options: &Options) {
     let key = &options.target_keys[0];
     let set_val = options.set_value.as_deref().unwrap_or("");
-    let new_line = format!("{}={}", key, set_val);
+    let new_line = if set_val.contains('\n') {
+        format!("{}=\"{}\"", key, set_val)
+    } else {
+        format!("{}={}", key, set_val)
+    };
 
     let env_object = options.env_object.as_ref().unwrap();
 

--- a/tests/set_and_delete.rs
+++ b/tests/set_and_delete.rs
@@ -92,6 +92,58 @@ fn add_multiline_value_single_line() {
 }
 
 #[test]
+fn add_value_with_real_newlines_via_stdin() {
+    let tmp = copy_env();
+    bin()
+        .arg("PEM_KEY")
+        .arg("--set")
+        .arg("-")
+        .arg("--file")
+        .arg(tmp.path())
+        .write_stdin("-----BEGIN KEY-----\nline2\nline3\n-----END KEY-----")
+        .assert()
+        .success();
+    bin()
+        .arg("PEM_KEY")
+        .arg("--file")
+        .arg(tmp.path())
+        .arg("--multiline")
+        .assert()
+        .success()
+        .stdout("-----BEGIN KEY-----\nline2\nline3\n-----END KEY-----\n");
+}
+
+#[test]
+fn update_existing_key_with_real_newlines_via_stdin() {
+    let tmp = copy_env();
+    bin()
+        .arg("NEW_ONE")
+        .arg("--set")
+        .arg("placeholder")
+        .arg("--file")
+        .arg(tmp.path())
+        .assert()
+        .success();
+    bin()
+        .arg("NEW_ONE")
+        .arg("--set")
+        .arg("-")
+        .arg("--file")
+        .arg(tmp.path())
+        .write_stdin("first\nsecond\nthird")
+        .assert()
+        .success();
+    bin()
+        .arg("NEW_ONE")
+        .arg("--file")
+        .arg(tmp.path())
+        .arg("--multiline")
+        .assert()
+        .success()
+        .stdout("first\nsecond\nthird\n");
+}
+
+#[test]
 fn update_existing_key() {
     let tmp = copy_env();
     bin()


### PR DESCRIPTION
- Quote values containing newline in `src/handlers/set_value.rs` to avoid breaking env-like lines and preserve value integrity.
- Add tests in `tests/set_and_delete.rs` to ensure newline content supplied via stdin is preserved and visible in multiline output.
- Verify updating an existing key with newline content via stdin overwrites the old value and remains retrievable as multiline.