### PR TITLE
Improve env parser for multi-line quotes

### DIFF
--- a/src/env_parser.rs
+++ b/src/env_parser.rs
@@ -16,6 +16,31 @@ fn get_end_line(lines: &[&str], start: usize, end_str: &str) -> usize {
     end
 }
 
+/// If `blob` looks like a JSON array, re-format it as `["a", "b", ...]`.
+/// Returns an error if it starts/ends like an array but isn't valid JSON.
+fn reformat_json_array_if_present(blob: String, start: usize) -> Result<String, EnvParseError> {
+    if blob.starts_with('[') && blob.ends_with(']') {
+        match serde_json::from_str::<Vec<serde_json::Value>>(&blob) {
+            Ok(arr) => {
+                let items: Vec<String> = arr
+                    .iter()
+                    .map(|item| match item {
+                        serde_json::Value::String(s) => format!("\"{}\"", s),
+                        other => other.to_string(),
+                    })
+                    .collect();
+                Ok(format!("[{}]", items.join(", ")))
+            }
+            Err(_) => Err(EnvParseError {
+                line: start + 1,
+                message: format!("Invalid list: {}", blob),
+            }),
+        }
+    } else {
+        Ok(blob)
+    }
+}
+
 /// Extract and normalise the value spanning lines[start..=end].
 ///
 /// - Takes everything after the first '=' on lines[start] (preserving '=' in values).
@@ -47,29 +72,81 @@ fn extract_value(
         blob = blob[1..blob.len() - 1].to_string();
     }
 
-    // Handle JSON array values: reformat as ["a", "b", ...]
-    if blob.starts_with('[') && blob.ends_with(']') {
-        match serde_json::from_str::<Vec<serde_json::Value>>(&blob) {
-            Ok(arr) => {
-                let items: Vec<String> = arr
-                    .iter()
-                    .map(|item| match item {
-                        serde_json::Value::String(s) => format!("\"{}\"", s),
-                        other => other.to_string(),
-                    })
-                    .collect();
-                blob = format!("[{}]", items.join(", "));
-            }
-            Err(_) => {
-                return Err(EnvParseError {
-                    line: start + 1,
-                    message: format!("Invalid list: {}", blob),
-                });
+    reformat_json_array_if_present(blob, start)
+}
+
+/// Find the line and byte offset of the quote character that closes a quoted
+/// value opened by `quote` at `open_pos` on `lines[start]`.
+///
+/// A candidate closing quote only counts if everything after it on that line
+/// (once trimmed) is empty or an inline `# comment` — this lets
+/// `KEY="value" # comment` close cleanly instead of being mistaken for an
+/// unterminated value, which used to silently swallow subsequent lines/keys
+/// into the value while scanning for a line that *ends* with a quote. Any
+/// other trailing junk after a quote character is treated the same as before:
+/// not closed yet, keep scanning (so a value that legitimately contains a
+/// stray quote character mid-value still resolves the same way it always did).
+///
+/// Errors instead of scanning to EOF if no closing quote is ever found, so an
+/// unterminated value fails loudly rather than absorbing the rest of the file.
+fn find_quote_close(
+    lines: &[&str],
+    start: usize,
+    open_pos: usize,
+    quote: char,
+) -> Result<(usize, usize), EnvParseError> {
+    let mut line_idx = start;
+    let mut search_from = open_pos + quote.len_utf8();
+    loop {
+        let line = lines[line_idx];
+        if let Some(rel) = line[search_from..].rfind(quote) {
+            let close_pos = search_from + rel;
+            let after = line[close_pos + quote.len_utf8()..].trim_start();
+            if after.is_empty() || after.starts_with('#') {
+                return Ok((line_idx, close_pos));
             }
         }
+        if line_idx + 1 >= lines.len() {
+            return Err(EnvParseError {
+                line: start + 1,
+                message: format!(
+                    "Unterminated quoted value starting on line {}: {}",
+                    start + 1,
+                    lines[start]
+                ),
+            });
+        }
+        line_idx += 1;
+        search_from = 0;
     }
+}
 
-    Ok(blob)
+/// Extract the value of a quoted (single- or double-quoted) KEY spanning
+/// lines[start..=end_line], given the byte offsets of the opening quote on
+/// lines[start] and the closing quote on lines[end_line] (as returned by
+/// `find_quote_close`). Everything from the closing quote onward on the last
+/// line — including a trailing `# comment` — is discarded.
+fn extract_quoted_value(
+    lines: &[&str],
+    start: usize,
+    end_line: usize,
+    open_pos: usize,
+    close_pos: usize,
+    quote: char,
+) -> Result<String, EnvParseError> {
+    let content_start = open_pos + quote.len_utf8();
+    let blob = if start == end_line {
+        lines[start][content_start..close_pos].to_string()
+    } else {
+        let mut parts: Vec<&str> = vec![&lines[start][content_start..]];
+        for line in lines.iter().take(end_line).skip(start + 1) {
+            parts.push(line);
+        }
+        parts.push(&lines[end_line][..close_pos]);
+        parts.join("\n")
+    };
+
+    reformat_json_array_if_present(blob, start)
 }
 
 /// Parse a .env file and return an EnvObject with resolved nested variables.
@@ -119,17 +196,17 @@ pub fn parse_env_file(file_path: &str) -> Result<EnvObject, EnvParseError> {
             continue;
         }
 
-        if value_part.starts_with('"') {
-            let end = get_end_line(&raw_lines, line_start, "\"");
-            let value = extract_value(&raw_lines, line_start, end, true)?;
-            env_object.set(
-                key,
-                EnvValue::with_lines(value, line_start as i64, end as i64),
-            );
-            i = end + 1;
-        } else if value_part.starts_with('\'') {
-            let end = get_end_line(&raw_lines, line_start, "'");
-            let value = extract_value(&raw_lines, line_start, end, true)?;
+        if value_part.starts_with('"') || value_part.starts_with('\'') {
+            let quote = value_part.chars().next().unwrap();
+            let first_line = raw_lines[line_start];
+            let raw_eq_pos = first_line.find('=').unwrap_or(0);
+            let open_pos = first_line[raw_eq_pos..]
+                .find(quote)
+                .map(|p| raw_eq_pos + p)
+                .unwrap_or(raw_eq_pos);
+            let (end, close_pos) = find_quote_close(&raw_lines, line_start, open_pos, quote)?;
+            let value =
+                extract_quoted_value(&raw_lines, line_start, end, open_pos, close_pos, quote)?;
             env_object.set(
                 key,
                 EnvValue::with_lines(value, line_start as i64, end as i64),

--- a/tests/env_parser.rs
+++ b/tests/env_parser.rs
@@ -1,5 +1,8 @@
 use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
 use std::path::Path;
+use tempfile::NamedTempFile;
 
 fn bin() -> Command {
     Command::cargo_bin("dotenv").unwrap()
@@ -8,6 +11,19 @@ fn bin() -> Command {
 fn env_path() -> String {
     let here = Path::new(env!("CARGO_MANIFEST_DIR"));
     here.join("tests/.env.test").to_string_lossy().to_string()
+}
+
+fn write_env(content: &str) -> NamedTempFile {
+    let mut tmp = NamedTempFile::new().unwrap();
+    tmp.write_all(content.as_bytes()).unwrap();
+    tmp
+}
+
+fn env_json(tmp: &NamedTempFile) -> serde_json::Value {
+    let output = bin().arg("--file").arg(tmp.path()).output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected valid JSON, got {:?}: {}", stdout, e))
 }
 
 #[test]
@@ -22,4 +38,69 @@ fn parse_file_count_keys() {
     let json: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
     let count = json.as_object().unwrap().len();
     assert!(count >= 9, "expected at least 9 keys, got {}", count);
+}
+
+// Regression tests for a bug where a trailing inline `# comment` after a
+// quoted value's closing quote defeated the "does the line end with a quote"
+// check used to find that value's end. The parser would then keep scanning
+// forward for a line that literally ended in a quote character, silently
+// swallowing the next key's line into the value (and truncating it besides).
+
+#[test]
+fn double_quoted_value_with_trailing_comment_does_not_swallow_next_key() {
+    let tmp = write_env("DOUBLE=\"Double quotes\" # inline comment\nNEXT=after\n");
+    let json = env_json(&tmp);
+    assert_eq!(json["DOUBLE"], "Double quotes");
+    assert_eq!(json["NEXT"], "after");
+    assert_eq!(json.as_object().unwrap().len(), 2);
+}
+
+#[test]
+fn single_quoted_value_with_trailing_comment_does_not_swallow_next_key() {
+    let tmp = write_env("SINGLE='Single quotes' # inline comment\nNEXT=after\n");
+    let json = env_json(&tmp);
+    assert_eq!(json["SINGLE"], "Single quotes");
+    assert_eq!(json["NEXT"], "after");
+    assert_eq!(json.as_object().unwrap().len(), 2);
+}
+
+#[test]
+fn multiline_quoted_value_with_trailing_comment_on_closing_line() {
+    let tmp = write_env("MULTI=\"line one\nline two\" # inline comment\nNEXT=after\n");
+    let json = env_json(&tmp);
+    assert_eq!(json["MULTI"], "line one\nline two");
+    assert_eq!(json["NEXT"], "after");
+    assert_eq!(json.as_object().unwrap().len(), 2);
+}
+
+#[test]
+fn quoted_value_with_no_trailing_comment_is_unaffected() {
+    // Guards against the fix changing behaviour for the common (no-comment) case.
+    let tmp = write_env("DOUBLE=\"Double quotes\"\nNEXT=after\n");
+    let json = env_json(&tmp);
+    assert_eq!(json["DOUBLE"], "Double quotes");
+    assert_eq!(json["NEXT"], "after");
+}
+
+#[test]
+fn unquoted_value_keeps_trailing_hash_literally() {
+    // dotenv-cli has never supported inline comments after unquoted values;
+    // unlike the quoted case, an unquoted value is always a single line, so
+    // there's no risk of it swallowing a following key. Everything after '='
+    // is taken as the literal value, `#` included.
+    let tmp = write_env("PLAIN=bar # not a comment\nNEXT=after\n");
+    let json = env_json(&tmp);
+    assert_eq!(json["PLAIN"], "bar # not a comment");
+    assert_eq!(json["NEXT"], "after");
+}
+
+#[test]
+fn unterminated_quoted_value_fails_loudly_instead_of_swallowing_rest_of_file() {
+    let tmp = write_env("BROKEN=\"never closed\nNEXT=after\n");
+    bin()
+        .arg("--file")
+        .arg(tmp.path())
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("EnvParseError"));
 }


### PR DESCRIPTION
- Add robust multi-line quoted value parsing that honors inline comments and errors on unterminated quotes.
- Introduce `reformat_json_array_if_present` to canonicalize JSON array values and report invalid JSON.
- Centralize handling of JSON arrays and quoted values with new helpers, replacing ad-hoc logic in `extract_value`.
- Extend env parsing to support single- and double-quoted values spanning multiple lines.
- Add test scaffolding (temp file utilities and end-to-end JSON parsing) to enable deterministic dotenv tests.
- Add regression tests for trailing inline comments after quoted values, covering double- and single-quoted, multi-line, and unquoted cases, plus proper handling of unterminated quotes.