### PR TITLE
Modernize CI workflows; drop publish scripts

### DIFF
--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -139,7 +139,7 @@ jobs:
   publish-release:
     name: Publish release
     needs: build-release-assets
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source
         uses: actions/checkout@v7
@@ -156,30 +156,32 @@ jobs:
 
       - name: Set up Node for npm
         if: steps.publish.outputs.published == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - name: Install package dependencies
         if: steps.publish.outputs.published == 'true'
-        run: npm ci --ignore-scripts
+        run: |
+          npm install -g npm@latest
+          npm ci --ignore-scripts
 
       - name: Publish to npm
         if: steps.publish.outputs.published == 'true'
-        run: |
-          npm install -g npm@latest
-          npm run publish:npm
+        run: npm publish --access public
 
       - name: Set up Node for GitHub Packages
         if: steps.publish.outputs.published == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com
+          package-manager-cache: false
 
       - name: Publish to GitHub Packages
         if: steps.publish.outputs.published == 'true'
-        run: npm run publish:github
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       target_branch: ${{ steps.plan.outputs.target_branch }}
     steps:
       - name: Checkout selected branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 0
@@ -57,7 +57,7 @@ jobs:
       release_sha: ${{ steps.release_commit.outputs.release_sha }}
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.plan.outputs.target_branch }}
           fetch-depth: 0
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.prepare_release.outputs.release_sha }}
 

--- a/.github/workflows/test.node.yml
+++ b/.github/workflows/test.node.yml
@@ -5,6 +5,9 @@ on:
     workflows: ["Release Assets"]
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
@@ -16,7 +19,7 @@ jobs:
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @mikegarde/dotenv-cli

--- a/.github/workflows/test.rust.yml
+++ b/.github/workflows/test.rust.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test and Coverage
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "build": "cargo build --release",
     "test": "cargo clippy --all-targets --all-features -- -D warnings && cargo test --all-features",
     "pack:dry-run": "npm pack --dry-run",
-    "publish:npm": "npm publish --access public --registry https://registry.npmjs.org",
-    "publish:github": "npm publish --access public --registry https://npm.pkg.github.com",
     "postinstall": "node ./postinstall.js"
   },
   "engines": {


### PR DESCRIPTION
- Update release-assets.yml to current CI standards: use ubuntu-latest, disable package-manager-cache, and publish via npm publish --access public for consistency across registries.
- release.yml: upgrade actions/checkout usages from v4 to v7 for better compatibility and fixes.
- test.node.yml: enable repository contents read permissions and upgrade setup-node to v7 for newer features and security.
- test.rust.yml: upgrade checkout to v7 and explicitly grant repository contents read access to prevent permission issues during tests.
- package.json: remove local publish scripts to centralize publishing through CI/CD.